### PR TITLE
clarify `/cmd` advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Main applications for this project.
 
 The directory name for each application should match the name of the executable you want to have (e.g., `/cmd/myapp`).
 
-Don't put a lot of code in the application directory unless you think that code can be imported and used in other projects. If this is the case then the code should live in the `/pkg` directory.
+Don't put a lot of code in the application directory.  If you think the code can be imported and used in other projects, then it should live in the `/pkg` directory.
 
 It's common to have a small main function that imports and invokes the code from the `/internal` and `/pkg` directories.
 


### PR DESCRIPTION
I'm confused by the `/cmd` instructions -- they seem to be contradicting themselves:

 - "Don't put a lot of code in the application directory unless you think that code can be imported and used in other projects" -> I'm interpreting that as saying "it's okay to put lots of code in the application directory"
 - "If [there's lots of code that can be imported and used in other projects] then the code should live in the `/pkg` directory." -> seems to be saying "it's *not* okay to put lots of code in the application directory"

I'm guessing the intent is more along the lines of:

 - don't put lots of code in the application directory
 - code for reuse should be in the pkd directory

So I edited to reflect that.

Thanks for putting this awesome resource together, and thanks for taking a look at my PR!