### PR TITLE
A not found link is removed from examples within the pkg directory

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -39,7 +39,6 @@ Examples:
 * https://github.com/knative/serving/tree/master/pkg
 * https://github.com/grafana/loki/tree/master/pkg
 * https://github.com/bloomberg/goldpinger/tree/master/pkg
-* https://github.com/crossplaneio/crossplane/tree/master/pkg
 * https://github.com/Ne0nd0g/merlin/tree/master/pkg
 * https://github.com/jenkins-x/jx/tree/master/pkg
 * https://github.com/DataDog/datadog-agent/tree/master/pkg


### PR DESCRIPTION
I noticed that **[crossplane/crossplane](https://github.com/crossplane/crossplane)** doesn't have the pkg directory any more.

They moved everything  in pkg to internal directory ([pull request](https://github.com/crossplane/crossplane/pull/1998))

Thanks for this repo. 