### PR TITLE
Added .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,22 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{*.go,Makefile,.gitmodules,go.mod,go.sum}]
+indent_style = tab
+
+[*.md]
+indent_style = tab
+trim_trailing_whitespace = false
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.{js,jsx,ts,tsx,css,less,sass,scss,vue,py}]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
Editorconfig is more or less standard now to enforce coding style. It might be a good idea to have one in the project, reflecting GO defaults while also using the industry standard / recommended settings for other files that are very likely to be included in a GO project.