### PR TITLE
removed satellity link

### DIFF
--- a/cmd/README.md
+++ b/cmd/README.md
@@ -15,6 +15,5 @@ Examples:
 * https://github.com/prometheus/prometheus/tree/master/cmd
 * https://github.com/influxdata/influxdb/tree/master/cmd
 * https://github.com/kubernetes/kubernetes/tree/master/cmd
-* https://github.com/satellity/satellity/tree/master/cmd/satellity
 * https://github.com/dapr/dapr/tree/master/cmd
 


### PR DESCRIPTION
satellity project doesn't use app folder more

link not found