### PR TITLE
Remove broken pkg links

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -13,7 +13,6 @@ The `pkg` directory origins: The old Go source code used to use `pkg` for its pa
 
 Examples:
 
-* https://github.com/prometheus/prometheus/tree/master/pkg
 * https://github.com/jaegertracing/jaeger/tree/master/pkg
 * https://github.com/istio/istio/tree/master/pkg
 * https://github.com/GoogleContainerTools/kaniko/tree/master/pkg

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -19,7 +19,6 @@ Examples:
 * https://github.com/google/gvisor/tree/master/pkg
 * https://github.com/google/syzkaller/tree/master/pkg
 * https://github.com/perkeep/perkeep/tree/master/pkg
-* https://github.com/minio/minio/tree/master/pkg
 * https://github.com/heptio/ark/tree/master/pkg
 * https://github.com/argoproj/argo/tree/master/pkg
 * https://github.com/heptio/sonobuoy/tree/master/pkg


### PR DESCRIPTION
The projects `prometheus` and `minio` don't use the `pkg` folder anymore.