### PR TITLE
Remove link that leads to 404

### DIFF
--- a/pkg/README.md
+++ b/pkg/README.md
@@ -13,7 +13,6 @@ The `pkg` directory origins: The old Go source code used to use `pkg` for its pa
 
 Examples:
 
-* https://github.com/prometheus/prometheus/tree/master/pkg
 * https://github.com/jaegertracing/jaeger/tree/master/pkg
 * https://github.com/istio/istio/tree/master/pkg
 * https://github.com/GoogleContainerTools/kaniko/tree/master/pkg


### PR DESCRIPTION
Remove link that leads to 404 because project have deprecated their `pkg` directory

It looks like Prometheus have stopped using a top level `pkg` folder.