### PR TITLE
feat: add iam project example to corresponding directory

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -6,3 +6,4 @@ Examples:
 
 * https://github.com/kubernetes/kubernetes/tree/master/api
 * https://github.com/moby/moby/tree/master/api
+* https://github.com/marmotedu/iam/tree/master/api

--- a/build/README.md
+++ b/build/README.md
@@ -9,3 +9,4 @@ Put your CI (travis, circle, drone) configurations and scripts in the `/build/ci
 Examples:
 
 * https://github.com/cockroachdb/cockroach/tree/master/build
+* https://github.com/marmotedu/iam/tree/master/build

--- a/cmd/README.md
+++ b/cmd/README.md
@@ -17,3 +17,4 @@ Examples:
 * https://github.com/kubernetes/kubernetes/tree/master/cmd
 * https://github.com/dapr/dapr/tree/master/cmd
 * https://github.com/ethereum/go-ethereum/tree/master/cmd
+* https://github.com/marmotedu/iam/tree/master/cmd

--- a/configs/README.md
+++ b/configs/README.md
@@ -3,3 +3,7 @@
 Configuration file templates or default configs.
 
 Put your `confd` or `consul-template` template files here.
+
+Examples:
+
+* https://github.com/marmotedu/iam/tree/master/configs

--- a/deployments/README.md
+++ b/deployments/README.md
@@ -1,3 +1,7 @@
 # `/deployments`
 
 IaaS, PaaS, system and container orchestration deployment configurations and templates (docker-compose, kubernetes/helm, mesos, terraform, bosh).
+
+Examples:
+
+* https://github.com/marmotedu/iam/tree/master/deployments

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,3 +7,4 @@ Examples:
 * https://github.com/gohugoio/hugo/tree/master/docs
 * https://github.com/openshift/origin/tree/master/docs
 * https://github.com/dapr/dapr/tree/master/docs
+* https://github.com/marmotedu/iam/tree/master/docs

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,3 +8,4 @@ Examples:
 * https://github.com/docker-slim/docker-slim/tree/master/examples
 * https://github.com/gohugoio/hugo/tree/master/examples
 * https://github.com/hashicorp/packer/tree/master/examples
+* https://github.com/marmotedu/iam/tree/master/examples

--- a/githooks/README.md
+++ b/githooks/README.md
@@ -1,3 +1,7 @@
 # `/githooks`
 
 Git hooks.
+
+Examples:
+
+* https://github.com/marmotedu/iam/tree/master/githooks

--- a/init/README.md
+++ b/init/README.md
@@ -1,3 +1,7 @@
 # `/init`
 
 System init (systemd, upstart, sysv) and process manager/supervisor (runit, supervisord) configs.
+
+Examples:
+
+* https://github.com/marmotedu/iam/tree/master/init

--- a/internal/README.md
+++ b/internal/README.md
@@ -12,9 +12,11 @@ Examples:
 * https://github.com/jaegertracing/jaeger/tree/master/internal
 * https://github.com/moby/moby/tree/master/internal
 * https://github.com/satellity/satellity/tree/master/internal
+* https://github.com/marmotedu/iam/tree/master/internal
 
 ## `/internal/pkg`
 
 Examples:
 
 * https://github.com/hashicorp/waypoint/tree/main/internal/pkg
+* https://github.com/marmotedu/iam/tree/master/internal/pkg

--- a/pkg/README.md
+++ b/pkg/README.md
@@ -56,3 +56,4 @@ Examples:
 * https://github.com/kata-containers/runtime/tree/master/pkg
 * https://github.com/okteto/okteto/tree/master/pkg
 * https://github.com/solo-io/squash/tree/master/pkg
+* https://github.com/marmotedu/iam/tree/master/pkg

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,3 +9,4 @@ Examples:
 * https://github.com/kubernetes/helm/tree/master/scripts
 * https://github.com/cockroachdb/cockroach/tree/master/scripts
 * https://github.com/hashicorp/terraform/tree/master/scripts
+* https://github.com/marmotedu/iam/tree/master/scripts

--- a/test/README.md
+++ b/test/README.md
@@ -5,5 +5,4 @@ Additional external test apps and test data. Feel free to structure the `/test` 
 Examples:
 
 * https://github.com/openshift/origin/tree/master/test (test data is in the `/testdata` subdirectory)
-
-
+* https://github.com/marmotedu/iam/tree/master/test

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -1,3 +1,7 @@
 # `/third_party`
 
 External helper tools, forked code and other 3rd party utilities (e.g., Swagger UI).
+
+Examples:
+
+* https://github.com/marmotedu/iam/tree/master/third_party

--- a/tools/README.md
+++ b/tools/README.md
@@ -7,3 +7,4 @@ Examples:
 * https://github.com/istio/istio/tree/master/tools
 * https://github.com/openshift/origin/tree/master/tools
 * https://github.com/dapr/dapr/tree/master/tools
+* https://github.com/marmotedu/iam/tree/master/tools


### PR DESCRIPTION
Add iam project example to corresponding directory. iam is a 2000+ stars project that strictly follows the project-layout directory structure