### PR TITLE
remove dead link in /examples folder

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,5 +6,4 @@ Examples:
 
 * https://github.com/nats-io/nats.go/tree/master/examples
 * https://github.com/docker-slim/docker-slim/tree/master/examples
-* https://github.com/gohugoio/hugo/tree/master/examples
 * https://github.com/hashicorp/packer/tree/master/examples


### PR DESCRIPTION
hi , it seems they removed examples folder in hugo. so i removed it 
[https://github.com/gohugoio/hugo/tree/master/examples](url)