### PR TITLE
Typo 'example' in french translation

### DIFF
--- a/README_fr.md
+++ b/README_fr.md
@@ -93,7 +93,7 @@ Depuis sa version [`1.13`](https://golang.org/doc/go1.13#modules), Go active la 
 
 Spécifications OpenAPI/Swagger, fichiers de schémas JSON, fichiers de définitions de protocoles.
 
-Voir le dossier [`/api`](api/README.md) pour des examples.
+Voir le dossier [`/api`](api/README.md) pour des exemples.
 
 ## Les répertoires d'application web
 


### PR DESCRIPTION
In french 'example' is translated to 'exemple'